### PR TITLE
Add support to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All contributions are welcome. Please follow [Development](#development) steps t
 ## Tech
 
 * [Python 2.7](https://www.python.org/download/releases/2.7/)
+* [Python 3](https://www.python.org/downloads/release/python-373/)
 
 
 ## Installation
@@ -209,7 +210,7 @@ def hello(name):
 # dyc.yaml
 
 formats:
-  - 
+  -
     extension: 'py'
     method:
       indent: 'tab'

--- a/dyc/base.py
+++ b/dyc/base.py
@@ -20,7 +20,7 @@ class Builder(object):
             filename = fileinput.filename()
             lineno = fileinput.lineno()
             keywords = self.config.get('keywords')
-            found = len(filter(lambda word: word.lstrip() in keywords, line.split(' '))) > 0
+            found = len([word.lstrip() for word in line.split(' ') if word.lstrip() in keywords]) > 0
 
             if change and found:
                 found = self._is_line_part_of_patches(lineno, line, patches)
@@ -165,4 +165,4 @@ class Processor(FilesDirector, FormatsDirector):
         """
         Property that returns all the allowed extensions
         """
-        return filter(None, map(lambda fmt: fmt.get('extension'), self.config.get('formats')))
+        return list(filter(None, map(lambda fmt: fmt.get('extension'), self.config.get('formats'))))

--- a/dyc/base.py
+++ b/dyc/base.py
@@ -1,5 +1,5 @@
 import fileinput
-from utils import all_files_generator, get_file_lines
+from .utils import all_files_generator, get_file_lines
 
 
 class Builder(object):

--- a/dyc/diff.py
+++ b/dyc/diff.py
@@ -9,8 +9,8 @@ The file will patch will undergo the process of:
 import os
 import git
 import ntpath
-from utils import get_hunk, get_additions_in_first_hunk
-from base import Processor
+from .utils import get_hunk, get_additions_in_first_hunk
+from .base import Processor
 
 
 class DiffParser():

--- a/dyc/dyc.py
+++ b/dyc/dyc.py
@@ -1,8 +1,8 @@
 import click
-from parser import ParsedConfig
-from main import DYC
-from diff import Diff
-from events import Watcher
+from .parser import ParsedConfig
+from .main import DYC
+from .diff import Diff
+from .events import Watcher
 import sys
 import time
 import logging

--- a/dyc/events.py
+++ b/dyc/events.py
@@ -3,8 +3,8 @@ import time
 import logging
 from watchdog.observers import Observer
 from watchdog.events import LoggingEventHandler
-from diff import Diff
-from main import DYC
+from .diff import Diff
+from .main import DYC
 
 class WatchEvent(LoggingEventHandler):
 
@@ -52,5 +52,3 @@ class Watcher:
             observer.stop()
             print('Quitting..')
         observer.join()
-
-

--- a/dyc/main.py
+++ b/dyc/main.py
@@ -5,9 +5,9 @@ DYC (Document Your Code) Class initiator
 is constructed here. It performs all the readings
 
 """
-from utils import get_extension
-from methods import MethodBuilder
-from base import Processor
+from .utils import get_extension
+from .methods import MethodBuilder
+from .base import Processor
 
 class DYC(Processor):
 

--- a/dyc/methods.py
+++ b/dyc/methods.py
@@ -4,8 +4,8 @@ import fileinput
 import copy
 import linecache
 import click
-from utils import get_leading_whitespace, BlankFormatter, get_indent, add_start_end
-from base import Builder
+from .utils import get_leading_whitespace, BlankFormatter, get_indent, add_start_end
+from .base import Builder
 
 
 class MethodBuilder(Builder):
@@ -385,7 +385,7 @@ class ArgumentDetails(object):
             self.args = filter(lambda x: x not in ignore, filter(None, [arg.strip() for arg in args]))
         except:
             pass
-        
+
     def sanitize(self):
         """
         Sanitizes arguments to validate all arguments are correct

--- a/dyc/methods.py
+++ b/dyc/methods.py
@@ -140,7 +140,7 @@ class MethodBuilder(Builder):
         if not self.details:
             yield None
 
-        for filename, func_pack in self.details.iteritems():
+        for filename, func_pack in self.details.items():
             for method_interface in func_pack.values():
                 yield method_interface
 
@@ -225,7 +225,7 @@ class MethodFormatter():
         """
         Main function for wrapping up argument docstrings
         """
-        if not len(self.arguments):
+        if not self.arguments:  # if len(self.arguments) == 0
             self.method_format['argument_format'] = ''
             self.method_format['break_before_close'] = ''
             self.method_format['empty_line'] = ''
@@ -241,7 +241,7 @@ class MethodFormatter():
 
         result = []
 
-        if len(self.arguments):
+        if self.arguments:  # if len(self.arguments) > 0
             for argument_details in self.arg_docstring:
                 argument_details['prefix'] = self.argument_format.get('prefix')
                 result.append(self.fmt.format(formatted_args, **argument_details).strip())

--- a/dyc/utils.py
+++ b/dyc/utils.py
@@ -11,7 +11,7 @@ INDENT_OPTIONS = {
 }
 
 
-def get_leading_whitespace(s): 
+def get_leading_whitespace(s):
     """
     Gets the leading whitespace of a string. Mainly used to
     determine how many space were there originally before adding a
@@ -21,13 +21,13 @@ def get_leading_whitespace(s):
     ----------
     str s: String text
     """
-    accumulator = [] 
-    for c in s: 
-        if c in ' \t\v\f\r\n': 
-            accumulator.append(c) 
-        else: 
-            break 
-    return ''.join(accumulator) 
+    accumulator = []
+    for c in s:
+        if c in ' \t\v\f\r\n':
+            accumulator.append(c)
+        else:
+            break
+    return ''.join(accumulator)
 
 
 def read_yaml(path):
@@ -95,7 +95,7 @@ def all_files_generator(extensions=[]):
     for root, dirs, files in os.walk(os.getcwd()):
         files = [os.path.join(root, f) for f in files if not f[0] == '.']
         dirs[:] = [d for d in dirs if not d[0] == '.']
-        if len(extensions):
+        if extensions:
             files = [filename for filename in files if get_extension(filename) in extensions]
         yield files
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="document-your-code",
-    version="0.1.3",
+    version="0.1.4",
     author="Mohammad Albakri",
     author_email="mohammad.albakri93@gmail.com",
     packages=find_packages(),


### PR DESCRIPTION
As promised in issue #8, this PR will fix the problems keeping it from working in Python 3
unfortunately I was not able to test it for `dyc diff` (I did not understood what this command actually does, maybe README could be more clear?), could you test it for me @Zarad1993 ?

Also, I tried to remove every `len()` call in the code that could cause some error as explained in #8 . Most of them could just be changed to removing `len(x)` as calling `if x` returned 0 if x is empty. Still, I avoided changing things that appears to be working, specially the `filter()` functions. filter() is not considered Pythonic (and can be quite hard to read), and a thing that I think could improve the code is changing filter() calls to [list comprehension](https://stackoverflow.com/questions/33944647/what-is-the-most-pythonic-way-to-filter-a-set/33944663) as I had to do in base.py line 23. It even allows the usage of len() again!
I kept away from doing this because it's out of the scope of this issue and could brake things that are working

Thank you very much for your time to review this, I'm here for any clarifications or changes necessary