### PR TITLE
Make "build passing" and "downloads" in README open pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 </p>
 
 <p align="center">
-  <img src="https://travis-ci.com/Zarad1993/dyc.svg?branch=master" alt="Build Status"/>
-  <img src="https://pepy.tech/badge/document-your-code/month" alt="Downloads"/>
+  <a href="https://travis-ci.com/Zarad1993/dyc"><img src="https://travis-ci.com/Zarad1993/dyc.svg?branch=master" alt="Build Status"></a>
+  <a href="https://pepy.tech/project/document-your-code"><img src="https://pepy.tech/badge/document-your-code/month" alt="Downloads"></a>
 </p>
 
 DYC is a CLI tool that helps with documenting your source code. It will help keep you alert for new methods that were added and not documented.


### PR DESCRIPTION
Before this commit, when you click _build passing_ or _downloads_ in README, it opens only an image. Now, it will open the link to its page in TRAVIS or PePy, respectively.