### PR TITLE
Add Base constructor

### DIFF
--- a/dyc/base.py
+++ b/dyc/base.py
@@ -3,6 +3,11 @@ from .utils import all_files_generator, get_file_lines
 
 
 class Builder(object):
+    def __init__(self, filename, config, placeholders=False):
+        self.filename = filename
+        self.config = config
+        self.placeholders = placeholders
+        
     details = dict()
 
     def initialize(self, change=None):

--- a/dyc/methods.py
+++ b/dyc/methods.py
@@ -11,10 +11,6 @@ from .base import Builder
 class MethodBuilder(Builder):
     already_printed_filepaths = []  # list of already printed files
 
-    def __init__(self, filename, config, placeholders=False):
-        self.filename = filename
-        self.config = config
-        self.placeholders = placeholders
 
     def extract_and_set_information(self, filename, start, line, length):
         """


### PR DESCRIPTION
The purpose of this change is to add abstraction to the base class Builder. Previously, the Base class was too specific to the implementation of method doc strings, this allows the inherited members to be able to share the skeleton of what makes up a doc string