### PR TITLE
Prevent commented methods from being nominated

### DIFF
--- a/dyc/base.py
+++ b/dyc/base.py
@@ -33,7 +33,7 @@ class Builder(object):
                         if word.lstrip() in keywords
                     ]
                 )
-                > 0
+                > 0 and line.lstrip(' ')[0] != '#' # line is not a comment line
             )
 
             if change and found:

--- a/dyc/base.py
+++ b/dyc/base.py
@@ -33,7 +33,8 @@ class Builder(object):
                         if word.lstrip() in keywords
                     ]
                 )
-                > 0 and line.lstrip(' ')[0] != '#' # line is not a comment line
+                > 0
+                and line.lstrip(' ')[0] != '#'  # line is not a comment line
             )
 
             if change and found:


### PR DESCRIPTION
I think this fixes the bug. Do I have to write any tests for this?

Fixes #25  