### PR TITLE
Added --no-prompts (-n) flag

### DIFF
--- a/dyc/base.py
+++ b/dyc/base.py
@@ -10,7 +10,7 @@ class Builder(object):
 
     details = dict()
 
-    def initialize(self, change=None):
+    def initialize(self, no_prompts, change=None):
         """
         The Builder's main method. It stores all the changes that needs to be made
         in `self.details` for a file. Which would then be used to add Docstrings to.
@@ -19,17 +19,17 @@ class Builder(object):
 
         patches = []
         if change:
-            patches = change.get('additions')
+            patches = change.get("additions")
 
         for line in fileinput.input(self.filename):
             filename = fileinput.filename()
             lineno = fileinput.lineno()
-            keywords = self.config.get('keywords')
+            keywords = self.config.get("keywords")
             found = (
                 len(
                     [
                         word.lstrip()
-                        for word in line.split(' ')
+                        for word in line.split(" ")
                         if word.lstrip() in keywords
                     ]
                 )
@@ -47,7 +47,7 @@ class Builder(object):
                 result = self.extract_and_set_information(
                     filename, lineno, line, length
                 )
-                if self.validate(result):
+                if self.validate(no_prompts, result):
                     self.details[filename][result.name] = result
 
     def _is_line_part_of_patches(self, lineno, line, patches):
@@ -61,10 +61,10 @@ class Builder(object):
         """
         result = False
         for change in patches:
-            start, end = change.get('hunk')
+            start, end = change.get("hunk")
             if start <= lineno <= end:
-                patch = change.get('patch')
-                found = filter(lambda l: line.replace('\n', '') == l, patch.split('\n'))
+                patch = change.get("patch")
+                found = filter(lambda l: line.replace("\n", "") == l, patch.split("\n"))
                 if found:
                     result = True
                     break
@@ -95,7 +95,7 @@ class Builder(object):
 
 class FilesDirector:
 
-    WILD_CARD = ['.', '*']
+    WILD_CARD = [".", "*"]
 
     def prepare_files(self, files=[]):
         """
@@ -128,9 +128,9 @@ class FilesDirector:
         ----------
         list files: Pre-given files list
         """
-        if self.config.get('file_list'):
+        if self.config.get("file_list"):
             # File list has already been passed
-            self.file_list = self.config.get('file_list')
+            self.file_list = self.config.get("file_list")
             return
 
         if len(files):
@@ -152,7 +152,7 @@ class FormatsDirector:
         """
         Function that prepares allowed formats
         """
-        self.formats = {ext.get('extension'): ext for ext in self.config.get('formats')}
+        self.formats = {ext.get("extension"): ext for ext in self.config.get("formats")}
 
 
 class Processor(FilesDirector, FormatsDirector):
@@ -184,6 +184,6 @@ class Processor(FilesDirector, FormatsDirector):
         """
         return list(
             filter(
-                None, map(lambda fmt: fmt.get('extension'), self.config.get('formats'))
+                None, map(lambda fmt: fmt.get("extension"), self.config.get("formats"))
             )
         )

--- a/dyc/dyc.py
+++ b/dyc/dyc.py
@@ -28,38 +28,55 @@ def main(config):
 
 
 @main.command()
-@click.option('--placeholders', is_flag=True, default=False)
-@click.argument('files', nargs=-1, type=click.Path(exists=True), required=False)
+@click.option("--placeholders", is_flag=True, default=False)
+@click.option("--no-prompts", "-n", "no_prompts", is_flag=True, default=False)
+@click.argument("files", nargs=-1, type=click.Path(exists=True), required=False)
 @config
-def start(config, files, placeholders):
+def start(config, files, no_prompts, placeholders):
     """
     This is the entry point of starting DYC for the whole project.
     When you run `dyc start`. ParsedConfig will wrap all the
     files list going to loop
     over and add missing documentation on.
     """
+    if config.configErr and not no_prompts:
+        click.echo(
+            click.style(
+                "`dyc.yaml` Missing or Incorrectly formatted. USING default settings",
+                fg="cyan",
+            )
+        )
+
     if files:
-        config.plain['file_list'] = list(files)
-    dyc = DYC(config.plain, placeholders=placeholders)
+        config.plain["file_list"] = list(files)
+    dyc = DYC(config.plain, no_prompts=no_prompts, placeholders=placeholders)
     dyc.prepare()
     dyc.process_methods()
 
 
 @main.command()
 @click.option(
-    '--watch', help='Add default placeholder when watching', is_flag=True, default=False
+    "--watch", help="Add default placeholder when watching", is_flag=True, default=False
 )
 @config
 def diff(config, watch):
     """
     This argument will run DYC on DIFF patch only
     """
+    if config.configErr:
+        click.echo(
+            click.style(
+                "`dyc.yaml` Missing or Incorrectly formatted. USING default settings",
+                fg="cyan",
+            )
+        )
+
     if watch:
         Watcher.start(config)
     else:
         diff = Diff(config.plain)
         uncommitted = diff.uncommitted
-        paths = [idx.get('path') for idx in uncommitted]
+        paths = [idx.get("path") for idx in uncommitted]
         if len(uncommitted):
             dyc = DYC(config.plain)
             dyc.prepare(files=paths)

--- a/dyc/main.py
+++ b/dyc/main.py
@@ -12,9 +12,10 @@ from .base import Processor
 
 
 class DYC(Processor):
-    def __init__(self, config, details=None, placeholders=False):
+    def __init__(self, config, no_prompts, details=None, placeholders=False):
         self.config = config
-        self.placeholders = placeholders
+        self.no_prompts = no_prompts
+        self.placeholders = True if no_prompts else placeholders
 
     def process_methods(self, diff_only=False, changes=[]):
         """
@@ -26,15 +27,17 @@ class DYC(Processor):
         bool diff_only: Use a diff only. Consumed by dyc diff.
         list changes: Changes in a file, mainly use also with dyc diff.
         """
-        print("\nProcessing Methods\n\r")
+        if not self.no_prompts:
+            print("\nProcessing Methods\n\r")
         for filename in self.file_list:
 
             try:
                 change = list(filter(lambda x: x.get("path") == filename, changes))[0]
             except TypeError as e:
-                click.echo(
-                    click.style("Error %r: USING default settings" % e, fg="red")
-                )
+                if not no_prompts:
+                    click.echo(
+                        click.style("Error %r: USING default settings" % e, fg="red")
+                    )
                 return
             except IndexError:
                 change = None
@@ -46,7 +49,7 @@ class DYC(Processor):
             builder = MethodBuilder(
                 filename, method_cnf, placeholders=self.placeholders
             )
-            builder.initialize(change=change)
+            builder.initialize(self.no_prompts, change=change)
             builder.prompts()
             builder.apply()
             builder.clear(filename)

--- a/dyc/methods.py
+++ b/dyc/methods.py
@@ -61,7 +61,7 @@ class MethodBuilder(Builder):
             placeholders=self.placeholders,
         )
 
-    def validate(self, result):
+    def validate(self, no_prompts, result):
         """
         An abstract validator method that checks if the method is
         still valid and gives the final decision
@@ -78,13 +78,15 @@ class MethodBuilder(Builder):
             if (
                 self.filename not in self.already_printed_filepaths
             ):  # Print file of method to document
-                click.echo(
-                    "\n\nIn file {} :\n".format(
-                        click.style(
-                            os.path.join(*self.filename.split(os.sep)[-3:]), fg="red"
+                if not no_prompts:
+                    click.echo(
+                        "\n\nIn file {} :\n".format(
+                            click.style(
+                                os.path.join(*self.filename.split(os.sep)[-3:]),
+                                fg="red",
+                            )
                         )
                     )
-                )
                 self.already_printed_filepaths.append(self.filename)
             confirmed = (
                 True

--- a/dyc/parser.py
+++ b/dyc/parser.py
@@ -14,10 +14,6 @@ class ParsedConfig(Config):
         self.plain = copy.deepcopy(self.default)
         try:
             self.override()
+            self.configErr = False
         except AttributeError:
-            click.echo(
-                click.style(
-                    '`dyc.yaml` Missing or Incorrectly formatted. USING default settings',
-                    fg='cyan',
-                )
-            )
+            self.configErr = True


### PR DESCRIPTION
Took a stab at issue #19 . It seems to be working, though the flag only works with the ```start``` command, which I assume was the intended behavior. If needed, I can get look into the ```diff``` command. Used black to format the files I changed, which seems to have changed the quotes throughout.