### PR TITLE
Add support for unusual method declarations 

### DIFF
--- a/dyc/base.py
+++ b/dyc/base.py
@@ -21,20 +21,30 @@ class Builder(object):
         if change:
             patches = change.get('additions')
 
+        fileLines = list(fileinput.input(self.filename))
+        i = 0
+
         for line in fileinput.input(self.filename):
             filename = fileinput.filename()
             lineno = fileinput.lineno()
             keywords = self.config.get('keywords')
-            found = (
-                len(
-                    [
-                        word.lstrip()
-                        for word in line.split(' ')
-                        if word.lstrip() in keywords
-                    ]
-                )
-                > 0
-            )
+            foundList = [word.lstrip() for word in line.split(' ') if word.lstrip() in keywords]
+            found = (len(foundList)> 0)
+            # Checking an unusual format in method declaration
+            if foundList:
+                openP = line.count('(')
+                closeP = line.count(')')
+                if openP == closeP:
+                    pass
+                else:
+                    pos = i
+                    while openP != closeP:
+                        pos += 1
+                        line += fileLines[pos]
+                        openP = line.count('(')
+                        closeP = line.count(')')
+                    lineno = pos + 1
+            i = i + 1
 
             if change and found:
                 found = self._is_line_part_of_patches(lineno, line, patches)

--- a/dyc/methods.py
+++ b/dyc/methods.py
@@ -4,7 +4,7 @@ import fileinput
 import copy
 import linecache
 import click
-from .utils import get_leading_whitespace, BlankFormatter, get_indent, add_start_end
+from .utils import get_leading_whitespace, BlankFormatter, get_indent, add_start_end, is_one_line_method
 from .base import Builder
 import os
 
@@ -30,6 +30,10 @@ class MethodBuilder(Builder):
             start_line
         )  # Where function started
         method_string = start_line
+        if not is_one_line_method(start_line, self.config.get('keywords')):
+            method_string = line
+            linesBackwards = method_string.count("\n") - 1
+            start_leading_space = get_leading_whitespace(linecache.getline(filename, start - linesBackwards))
         line_within_scope = True
         lineno = start + 1
         line = linecache.getline(filename, lineno)
@@ -146,8 +150,24 @@ class MethodBuilder(Builder):
         for method_interface in self._method_interface_gen():
             if not method_interface:
                 continue
-
-            for line in fileinput.input(method_interface.filename, inplace=True):
+            fileInput = fileinput.input(method_interface.filename, inplace=True)
+            i = 0
+            
+            for line in fileInput:
+                tmpLine = line
+                if 'def' in line and ":" not in line:
+                    openedP = line.count("(")
+                    closedP = line.count(")")
+                    if openedP == closedP: continue
+                    else:
+                        pos = i + 1
+                        while openedP != closedP:
+                            tmpLine += fileInput[pos]
+                            openedP = tmpLine.count("(")
+                            closedP = tmpLine.count(")")
+                            pos += 1
+                        line = tmpLine
+                
                 if self._get_name(line) == method_interface.name:
                     if self.config.get("within_scope"):
                         sys.stdout.write(line + method_interface.result + "\n")
@@ -155,6 +175,7 @@ class MethodBuilder(Builder):
                         sys.stdout.write(method_interface.result + "\n" + line)
                 else:
                     sys.stdout.write(line)
+                i = i + 1
 
     def _method_interface_gen(self):
         """
@@ -177,7 +198,7 @@ class MethodBuilder(Builder):
         for keyword in self.config.get("keywords", []):
             clear_defs = re.sub("{} ".format(keyword), "", line.strip())
             name = re.sub(r"\([^)]*\)\:", "", clear_defs).strip()
-            if re.search(r"\((.*)\)", name):
+            if re.search(r"\(([\s\S]*)\)", name):
                 try:
                     name = re.match(r"^[^\(]+", name).group()
                 except:
@@ -316,7 +337,14 @@ class MethodFormatter:
         polished = add_start_end(polished)
         method_split = self.plain.split("\n")
         if self.config.get("within_scope"):
-            method_split.insert(1, polished)
+            # Check if method comes in an unusual format
+            keywords = self.config.get('keywords')
+            firstLine = method_split[0]
+            pos = 1
+            while not is_one_line_method(firstLine, keywords):
+                firstLine += method_split[pos]
+                pos += 1
+            method_split.insert(pos, polished)
         else:
             method_split.insert(0, polished)
 
@@ -448,9 +476,9 @@ class ArgumentDetails(object):
         """
         try:
             ignore = self.config.get("ignore")
-            args = re.search(r"\((.*)\)", self.line).group(1).split(", ")
+            args = re.search(r'\(([\s\S]*)\)', self.line).group(1).split(',')
             self.args = filter(
-                lambda x: x not in ignore, filter(None, [arg.strip() for arg in args])
+                lambda x: x not in ignore, filter(None, [arg.replace('\n', '').replace('\t', '').strip() for arg in args])
             )
         except:
             pass

--- a/dyc/utils.py
+++ b/dyc/utils.py
@@ -159,3 +159,18 @@ def get_additions_in_first_hunk(hunk):
     start = int(adds_patch[0])
     end = int(start) + int(adds_patch[1])
     return start, end
+
+
+def is_one_line_method(line, keywords):
+    """
+    Gets True if the line holds a complete method declaration (from 'def to :), 
+    otherwise it gets False
+    ----------
+    str line: Text line
+    """
+    found = [word.lstrip() for word in line.split(' ') if word.lstrip() in keywords]
+    if found:
+        openP = line.count('(')
+        closeP = line.count(')')
+        return openP == closeP
+    return bool(found)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from dyc.utils import get_leading_whitespace, read_yaml, get_indent, get_extension
+from dyc.utils import get_leading_whitespace, read_yaml, get_indent, get_extension, is_one_line_method
 
 
 class TestGetLeadingWhitespace:
@@ -57,3 +57,24 @@ class TestGetExtension:
         for ext in exts:
             got = get_extension(ext)
             assert expected == got
+
+
+class TestCheckReadLineMethod:
+    keys = ['def', 'function']
+    def test_is_one_line_method_complete(self):
+        line = 'function method(a, b, c):'
+        expected = True
+        got = is_one_line_method(line, self.keys)
+        assert expected == got
+        
+    def test_is_one_line_method_incomplete(self):
+        line = 'def method(a, b=(3, 1), c,'
+        expected = False
+        got = is_one_line_method(line, self.keys)
+        assert expected == got
+    
+    def test_is_one_line_method_any_line(self):
+        line = 'length = len(objects)'
+        expected = False
+        got = is_one_line_method(line, self.keys)
+        assert expected == got    


### PR DESCRIPTION
Adding flexibility for methods that are declared using newlines in the params section.
Now it works as normal as if it was declared in a single line.

Closes #24