### PR TITLE
Remove errant tab in pre-commit YAML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 -   repo: local
     hooks:
-    -   id: pre_commit_hook	
+    -   id: pre_commit_hook
         name: pre_commit_hook
         entry: dyc diff
         verbose: true


### PR DESCRIPTION
After installing the pre-commit hook, git would throw an error due to a tab character at the end of a line. The pre-commit hook now works as expected.

Error:
```
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
=====> while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 3, column 28:
        -   id: pre_commit_hook	
```