### PR TITLE
dyc start no longer errors out on unedited confirmation files

### DIFF
--- a/dyc/methods.py
+++ b/dyc/methods.py
@@ -377,7 +377,7 @@ class MethodFormatter:
                 "## CONFIRM: MODIFY DOCSTRING BETWEEN START AND END LINES ONLY\n\n"
                 + result
             )
-            message = "\n".join(message.split("\n")[2:])
+            message = result if message == None else "\n".join(message.split("\n")[2:])
         except:
             print("Quitting the program in the editor terminates the process. Thanks")
             sys.exit()


### PR DESCRIPTION
This commit should fix #54 as it does not error out when termui edit function returns None on unedited files in Vim. Therefore ZZ and :x are now valid ways to confirm the documentation.