### PR TITLE
Add missing docstrings for test methods

### DIFF
--- a/dyc/configs/__init__.py
+++ b/dyc/configs/__init__.py
@@ -13,7 +13,7 @@ class Config(object):
 
     def override(self):
         """
-        Entry point to Config, mainly the 
+        Entry point to Config, mainly the
         """
         self._override_basic()
         self._override_formats()

--- a/dyc/utils.py
+++ b/dyc/utils.py
@@ -164,7 +164,7 @@ def get_additions_in_first_hunk(hunk):
 
 def is_one_line_method(line, keywords):
     """
-    Gets True if the line holds a complete method declaration (from 'def to :), 
+    Gets True if the line holds a complete method declaration (from 'def to :),
     otherwise it gets False
     ----------
     str line: Text line

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,13 @@ from dyc.utils import (
 
 class TestGetLeadingWhitespace:
     def test_tabs(self):
+        """
+        Test getting a 'tab' indent from 'get_indent' utility function.
+        
+        Parameters
+        ----------
+        
+        """
         """Test tabs functionality"""
         text = '\t\tHello'
         expected = '\t\t'
@@ -26,6 +33,13 @@ class TestGetLeadingWhitespace:
 
 class TestReadYaml:
     def test_should_return_none_if_not_found(self):
+        """
+        Test should return 'None' if file does not exist.
+        
+        Parameters
+        ----------
+        
+        """
         random_path = '/path/to/non/existing/file.yaml'
         expected = None
         got = read_yaml(random_path)
@@ -34,32 +48,84 @@ class TestReadYaml:
 
 class TestGetIndent:
     def test_tabs(self):
+        """
+        Test getting a 'tab' indent from 'get_indent' utility function.
+        
+        Parameters
+        ----------
+        
+        """
         assert get_indent('tab') == '\t'
 
     def test_2_spaces(self):
+        """
+        Test getting a 2-space indent from 'get_indent' utility function.
+        
+        Parameters
+        ----------
+        
+        """
         assert get_indent('2 spaces') == '  '
 
     def test_falsy_value(self):
+        """
+        Test getting an empty ('falsy') indent from 'get_indent' utility function.
+        
+        Parameters
+        ----------
+        
+        """
         assert get_indent(False) == ''
 
     def test_default_4_spaces(self):
+        """
+        Test getting a default indent from 'get_indent' utility function and
+        verify it is 4 spaces.
+        
+        Parameters
+        ----------
+        
+        """
         assert get_indent(None) == '    '
 
 
 class TestGetExtension:
     def test_existing_extension_valid(self):
+        """
+        Test that 'get_extension' correctly returns filename extension when one exists.
+        
+        Parameters
+        ----------
+        
+        """
         ext = 'file.puk'
         expected = 'puk'
         got = get_extension(ext)
         assert expected == got
 
     def test_non_existing_extension(self):
+        """
+        Test that 'get_extension' returns an empty string when a filename
+        lacks an extension.
+        
+        Parameters
+        ----------
+        
+        """
         ext = 'file'
         expected = ''
         got = get_extension(ext)
         assert expected == got
 
     def test_wrong_extension_type(self):
+        """
+        Test that 'get_extension' returns an empty string when provided invalid
+        (non-string) arguments.
+        
+        Parameters
+        ----------
+        
+        """
         exts = [dict(), False, True, [], 123]
         expected = ''
         for ext in exts:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,10 +11,10 @@ class TestGetLeadingWhitespace:
     def test_tabs(self):
         """
         Test getting a 'tab' indent from 'get_indent' utility function.
-        
+
         Parameters
         ----------
-        
+
         """
         """Test tabs functionality"""
         text = '\t\tHello'
@@ -35,10 +35,10 @@ class TestReadYaml:
     def test_should_return_none_if_not_found(self):
         """
         Test should return 'None' if file does not exist.
-        
+
         Parameters
         ----------
-        
+
         """
         random_path = '/path/to/non/existing/file.yaml'
         expected = None
@@ -50,30 +50,30 @@ class TestGetIndent:
     def test_tabs(self):
         """
         Test getting a 'tab' indent from 'get_indent' utility function.
-        
+
         Parameters
         ----------
-        
+
         """
         assert get_indent('tab') == '\t'
 
     def test_2_spaces(self):
         """
         Test getting a 2-space indent from 'get_indent' utility function.
-        
+
         Parameters
         ----------
-        
+
         """
         assert get_indent('2 spaces') == '  '
 
     def test_falsy_value(self):
         """
         Test getting an empty ('falsy') indent from 'get_indent' utility function.
-        
+
         Parameters
         ----------
-        
+
         """
         assert get_indent(False) == ''
 
@@ -81,10 +81,10 @@ class TestGetIndent:
         """
         Test getting a default indent from 'get_indent' utility function and
         verify it is 4 spaces.
-        
+
         Parameters
         ----------
-        
+
         """
         assert get_indent(None) == '    '
 
@@ -93,10 +93,10 @@ class TestGetExtension:
     def test_existing_extension_valid(self):
         """
         Test that 'get_extension' correctly returns filename extension when one exists.
-        
+
         Parameters
         ----------
-        
+
         """
         ext = 'file.puk'
         expected = 'puk'
@@ -107,10 +107,10 @@ class TestGetExtension:
         """
         Test that 'get_extension' returns an empty string when a filename
         lacks an extension.
-        
+
         Parameters
         ----------
-        
+
         """
         ext = 'file'
         expected = ''
@@ -121,10 +121,10 @@ class TestGetExtension:
         """
         Test that 'get_extension' returns an empty string when provided invalid
         (non-string) arguments.
-        
+
         Parameters
         ----------
-        
+
         """
         exts = [dict(), False, True, [], 123]
         expected = ''


### PR DESCRIPTION
Add missing docstrings to `test_utils.py` (using `dyc`).

Output when running `dyc` in my workspace now looks like this:

```
(dyc-venv) [ndemers@localhost dyc]$ dyc start
`dyc.yaml` Missing or Incorrectly formatted. USING default settings

Processing Methods



In file dyc/dyc/utils.py :

Do you want to document method list keywords: list of keywords like for python, func for go etc.? [y/N]: 
(dyc-venv) [ndemers@localhost dyc]$ 
```

Note that there's another bug here--line 171 in `dyc/utils.py` is a docstring that contains the keyword `def` in it. Right now, there is no handling for docstrings that contain keywords, so the tool is incorrectly picking this up as a function/method definition.

I also ran `black --skip-string-normalization .` to update formatting of some files since they were in a format that was causing the CI quality checks to fail.

Testing:

* Built + installed `dyc`
* Ran `dyc` and observed that no files show up as needing documentation (except the one mentioned above which looks like a bug).
* Passes CI pipeline build + tests

@Zarad1993 